### PR TITLE
Add instruction to symlink the rollbar-agent bin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,10 @@ Or just grab the .tar.gz::
 Then install (may require sudo)::
 
     python setup.py install
+    
+Symlink the rollbar-agent executable to /usr/local/rollbar-agent:
+
+    ln -s /usr/local/rollbar-agent /path/to/rollbar-agent/rollbar-agent
 
 **init.d script**
 


### PR DESCRIPTION
The `rollbar-agent` init script won't run otherwise.
