### PR TITLE
Add the packaging metadata to build the rollbar-agent snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,3 +18,4 @@ parts:
     source: .
     plugin: python
     python-version: python2
+    requirements: requirements.txt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: rollbar-agent
+version: master
+summary: A daemon to monitor log files and push messages to Rollbar
+description: |
+  rollbar-agent is a Python daemon that can monitor log files and push messages
+  to Rollbar. It can monitor .rollbar files and Python-style log files
+
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+
+apps:
+  rollbar-agent:
+    command: rollbar-agent
+
+parts:
+  rollbar-agent:
+    source: .
+    plugin: python
+    python-version: python2


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.