### PR TITLE
Save rollbar state on errors

### DIFF
--- a/rollbar-agent
+++ b/rollbar-agent
@@ -447,14 +447,17 @@ class ScannerThread(threading.Thread):
         # Close the state file before recreating it
         self.save_state(state)
 
-        for app in self.apps.itervalues():
-            self.scan_app(app, apps_state)
-
-        # recreate the state file and save the new apps_state to trim
-        # any excess space being used by the old state file
-        state = self.load_state(recreate=True)
-        state['apps'] = apps_state
-        self.save_state(state)
+        try:
+            for app in self.apps.itervalues():
+                self.scan_app(app, apps_state)
+        except:
+            log.exception("Caught exception in ScannerThread.scan_all() loop")
+        finally:
+            # recreate the state file and save the new apps_state to trim
+            # any excess space being used by the old state file
+            state = self.load_state(recreate=True)
+            state['apps'] = apps_state
+            self.save_state(state)
 
     def load_state(self, recreate=False):
         if not options.dry_run:


### PR DESCRIPTION
In the event of a exception in `scan_app`, if we throw an exception, the agent will not save the state and will re-start reading and sending the entire file. This PR ensures that we save the state and retry even on exceptional cases so that the next retry is simply incremental

We ran into this issue in a scenario where we had thousands of rollbar errors in the log file and the agent never finishes a loop through `scan_all`, which means it keeps retrying  and seemingly never gets to new issues.

In our case, we keep hitting a `ConnectionError: ('Connection aborted.', error("(32, 'EPIPE')",))`, but that's a different issue from the POST to rollbar. Whether it's the same issue or not is unclear.
  