### PR TITLE
Support multiple spaces in in log_format.patterns

### DIFF
--- a/rollbar-agent
+++ b/rollbar-agent
@@ -280,7 +280,9 @@ class LogFileProcessor(Processor):
             pair = pair.strip()
             if not pair:
                 continue
-            pattern, format = pair.split(" ", 1)
+            # Using None as the separator means
+            # "runs of consecutive whitespace are regarded as a single separator"
+            pattern, format = pair.split(None, 1)
             if format in self.scanner.config['_formats']:
                 pattern = re.compile(fnmatch.translate(pattern))
                 self.pattern_parsers.append((pattern, self.scanner.config['_formats'][format]))

--- a/rollbar-agent.conf
+++ b/rollbar-agent.conf
@@ -45,6 +45,7 @@ log_format.default = pyramid
 # log formats for filename patterns (unix glob patterns). 
 # syntax: one declaration per line, space-separated, 
 # regex followed by format name
+# each line MUST have at least 1 leading white space character
 log_format.patterns = 
     celery*.log celery_process
 
@@ -57,6 +58,7 @@ min_log_level = INFO
 
 # regex patterns that will match strings to be replaced with asterisks
 # syntax: one regex pattern per line
+# each line MUST have at least 1 leading white space character
 scrub_regex_patterns = 
 
 # Uncomment the following line if your log file contains terminal control sequences for color


### PR DESCRIPTION
Fixes #7

We currently do not support multiple spaces between the format glob and
the format name. This PR fixes that by considering consecutive
whitespace as a single separator.

I also added documentation to the configuration file to make it clear
that at least 1 leading whitespace character is required to signify that
a line is a continuation of the previous.