### PR TITLE
Change _default_message_start_parser into a dictionary

### DIFF
--- a/rollbar-agent
+++ b/rollbar-agent
@@ -210,10 +210,10 @@ class Processor(object):
     def send_payload(self, payload):
         # do immediate http post
         # in the future, will do this with batches and single separate thread
-        
+
         if isinstance(payload, basestring):
             payload = payload.encode('utf8')
-        
+
         if options.dry_run:
             log.debug("Dry run; payload to send: %s", payload)
         else:
@@ -246,12 +246,12 @@ class RollbarFileProcessor(Processor):
             return
         try:
             payload = json.loads(line)
-            
+
             # use the agent's access token if one isn't defined for the loaded item
             if not payload.get('access_token'):
                 payload['access_token'] = self.app['config']['params.access_token']
                 line = json.dumps(payload)
-            
+
         except ValueError:
             log.warning("Could not process badly formatted line: %s", line)
             return
@@ -264,8 +264,12 @@ class LogFileProcessor(Processor):
     Processor for general log files - currently works reasonably well for paste/pylons log files.
     Some events we want will span multiple lines.
     """
-    # tuple of (pattern, strptime format)
-    _default_message_start_parser = (re.compile(r'(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),(\d+)?\s+(?P<level>[A-Z]+)\s+(?P<title>.*$)'), '%Y-%m-%d %H:%M:%S')
+    # dictionary of (pattern, strptime format and name)
+    _default_message_start_parser = {
+        'regex': re.compile(r'(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),(\d+)?\s+(?P<level>[A-Z]+)\s+(?P<title>.*$)'),
+        'datefmt': '%Y-%m-%d %H:%M:%S',
+        'name': 'default parser'
+    }
 
     def __init__(self, *args, **kw):
         super(LogFileProcessor, self).__init__(*args, **kw)

--- a/test.py
+++ b/test.py
@@ -20,8 +20,8 @@ class TestDefaultMessageStartParserUsage(unittest.TestCase):
 
     def test_process_log_debug_with_format_name(self):
         # check if default_parser uses valid format name provided in the config
-        config = {'_formats': {'pyramid': {'name': 'pyramid'}}
-                  }
+        config = {'_formats': {'pyramid': {'name': 'pyramid'}}}
+
         scanner = FakeScanner(config)
 
         new_processor = rollbar_agent.LogFileProcessor(scanner, self.app)
@@ -31,6 +31,7 @@ class TestDefaultMessageStartParserUsage(unittest.TestCase):
     def test_process_log_debug_without_format_name(self):
         # check if default_parser can access _default_message_start_parser if format name not provided in the config
         config = {'_formats': {}}
+        
         scanner = FakeScanner(config)
 
         new_processor = rollbar_agent.LogFileProcessor(scanner, self.app)

--- a/test.py
+++ b/test.py
@@ -1,30 +1,42 @@
 import unittest
+import imp
+
+rollbar_agent = imp.load_source('rollbar-agent', './rollbar-agent')
+
 
 class FakeScanner:
     def __init__(self, config):
         self.config = config
 
-class TestDefaultMessageStartParser(unittest.TestCase):
 
-    def test_process_log_debug(self):
+class TestDefaultMessageStartParserUsage(unittest.TestCase):
+    app = {'name': 'pyramid',
+           'config': {
+               'log_format.default': 'pyramid',
+               'log_format.patterns': 'celery*.log celery_process',
+               'min_log_level': 'INFO'
+           }
+           }
 
-        config = { '_formats': {'format': {}}
-
-        }
+    def test_process_log_debug_with_format_name(self):
+        # check if default_parser uses valid format name provided in the config
+        config = {'_formats': {'pyramid': {'name': 'pyramid'}}
+                  }
         scanner = FakeScanner(config)
-        app = { 'name': 'pyramid',
-                'config':
-                    {'params':  {'access_token': 1234},
-                                {'environment': 'production'}
-                    },
-                    {'log_format.default':'pyramid'},
-                    {'log_format.patterns': 'celery*.log celery_process'},
-                    {'min_log_level': 'INFO'}
-        }
 
-        new_processor = LogFileProcessor(scanner, app)
-        #check if default_parser is a dict and has valid name
-        self.assertEquals('pyramid', new_processor.default_parser['name'])
+        new_processor = rollbar_agent.LogFileProcessor(scanner, self.app)
+
+        self.assertEqual('pyramid', new_processor.default_parser['name'])
+
+    def test_process_log_debug_without_format_name(self):
+        # check if default_parser can access _default_message_start_parser if format name not provided in the config
+        config = {'_formats': {}}
+        scanner = FakeScanner(config)
+
+        new_processor = rollbar_agent.LogFileProcessor(scanner, self.app)
+
+        self.assertEqual('default parser', new_processor.default_parser['name'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -19,7 +19,7 @@ class TestDefaultMessageStartParserUsage(unittest.TestCase):
            }
 
     def test_process_log_debug_with_format_name(self):
-        # check if default_parser uses valid format name provided in the config
+        # check if self.default_parser uses valid format name provided in the config
         config = {'_formats': {'pyramid': {'name': 'pyramid'}}}
 
         scanner = FakeScanner(config)
@@ -29,9 +29,9 @@ class TestDefaultMessageStartParserUsage(unittest.TestCase):
         self.assertEqual('pyramid', new_processor.default_parser['name'])
 
     def test_process_log_debug_without_format_name(self):
-        # check if default_parser can access _default_message_start_parser if format name not provided in the config
+        # check if self.default_parser can access _default_message_start_parser if format name not provided in config
         config = {'_formats': {}}
-        
+
         scanner = FakeScanner(config)
 
         new_processor = rollbar_agent.LogFileProcessor(scanner, self.app)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,30 @@
+import unittest
+
+class FakeScanner:
+    def __init__(self, config):
+        self.config = config
+
+class TestDefaultMessageStartParser(unittest.TestCase):
+
+    def test_process_log_debug(self):
+
+        config = { '_formats': {'format': {}}
+
+        }
+        scanner = FakeScanner(config)
+        app = { 'name': 'pyramid',
+                'config':
+                    {'params':  {'access_token': 1234},
+                                {'environment': 'production'}
+                    },
+                    {'log_format.default':'pyramid'},
+                    {'log_format.patterns': 'celery*.log celery_process'},
+                    {'min_log_level': 'INFO'}
+        }
+
+        new_processor = LogFileProcessor(scanner, app)
+        #check if default_parser is a dict and has valid name
+        self.assertEquals('pyramid', new_processor.default_parser['name'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
rollbar agent throwing errors in logs #ch69379 https://app.clubhouse.io/rollbar/story/69379/rollbar-agent-throwing-errors-in-logs

When not provided with a parser name for default parser rollbar-agent will try to use the _default_message_start_parser, but the _default_message_start_parser is a tuple and it trows an error as tuples cannot be accessed by string used as a key.

To fix this I changed _default_message_start_parser into a dictionary 
