### PR TITLE
Cleanup package builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.nix
 Pipfile
 Pipfile.lock
+.python-version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,3 @@ include requirements.txt
 include rollbar-agent*
 exclude rollbar-agent.state
 exclude rollbar-agentc
-exclude pyproject.toml


### PR DESCRIPTION
## Description of the change

In its current state, Rollbar-Agent does not use `pyproject.toml` to manage the package, however, if the file exists (e.g. for local development) it's included in the source distribution. It may break package installation with the `pip` tool as the file is detected and used by the tool.
A temporary workaround (introduced by fc823ec) was to explicitly exclude the file via `MANIFEST.in`. However, this can lead to confusion in later development when we would eventually switch to use the `pyproject.toml` file.

This PR rolls back the workaround. It also adds `.python-version` to `.gitignore`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
